### PR TITLE
Remove the dependency from lib.rs on web.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,14 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+name = "pica"
+path = "src/lib.rs"
+
+[[bin]]
+name = "server"
+path = "src/bin/server/mod.rs"
+
 [dependencies]
 tokio = { version = "1.18.5", features = ["full"] }
 tokio-stream = { version = "0.1.8", features = ["sync"] }

--- a/src/bin/server/mod.rs
+++ b/src/bin/server/mod.rs
@@ -17,9 +17,11 @@ extern crate num_derive;
 extern crate num_traits;
 extern crate thiserror;
 
+mod web;
+
 use anyhow::Result;
 use clap::Parser;
-use pica::{web, Pica, PicaCommand};
+use pica::{Pica, PicaCommand};
 use std::net::{Ipv4Addr, SocketAddrV4};
 use std::path::PathBuf;
 use tokio::net::TcpListener;

--- a/static/index.html
+++ b/static/index.html
@@ -123,7 +123,7 @@ limitations under the License.
     console.log("Device Added", data);
 
     const {
-      device: { mac_address, x, y, z, yaw, pitch, roll },
+      mac_address, x, y, z, yaw, pitch, roll,
     } = data;
     map.devices = [
       ...map.devices,
@@ -143,7 +143,7 @@ limitations under the License.
     console.log("Device Removed", data);
 
     const {
-      device: { mac_address },
+      mac_address,
     } = data;
     if (info.device?.mac_address === mac_address) {
       info.device = null;
@@ -165,7 +165,7 @@ limitations under the License.
     console.log("Position updated", data);
 
     const {
-      device: { mac_address, x, y, z, yaw, pitch, roll },
+      mac_address, x, y, z, yaw, pitch, roll,
     } = data;
 
     const device = map.devices.find(
@@ -186,20 +186,20 @@ limitations under the License.
     console.log("Neighbor updated", data);
 
     const {
-      source_device: { mac_address: src_mac_address },
-      destination_device: { mac_address: dest_mac_address },
+      source_mac_address,
+      destination_mac_address,
       distance,
       azimuth,
       elevation,
     } = data;
 
     const device = map.devices.find(
-      (device) => device.mac_address === src_mac_address
+      (device) => device.mac_address === source_mac_address
     );
 
     const neighbor = device.neighbors.find(
-      (device) => device.mac_address == dest_mac_address
-    ) || { mac_address: dest_mac_address };
+      (device) => device.mac_address == destination_mac_address
+    ) || { mac_address: destination_mac_address };
 
     neighbor.distance = distance;
     neighbor.azimuth = azimuth;

--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -54,19 +54,23 @@ components:
         or an UCI Device as described in the Fira UCI Specification, noted `uci`.
       type: object
       properties:
-        Category:
-          description: Represents the device's category, uci or anchor.
-          type: string
-          enum: [uci, anchor]
-        MacAddress:
-          description: |
-            Valid UWB mac addresses must follow the above format
-              * Short Mode: "XX:XX"
-              * Extend Mode: "XX:XX:XX:XX:XX:XX:XX:XX"
-            where X is an hexadecimal number.
-          type: string
-        Position:
+        category:
+            $ref: "#/components/schemas/Category"
+        mac_address:
+            $ref: "#/components/schemas/MacAddress"
+        position:
             $ref: "#/components/schemas/Position"
+    Category:
+      description: Represents the device's category, uci or anchor.
+      type: string
+      enum: [uci, anchor]
+    MacAddress:
+      description: |
+        Valid UWB mac addresses must follow the above format
+          * Short Mode: "XX:XX"
+          * Extend Mode: "XX:XX:XX:XX:XX:XX:XX:XX"
+        where X is an hexadecimal number.
+      type: string
     Position:
       description:
         The position includes the Cartesian coordinates in cm, and the yaw, pitch, roll angles in degrees.
@@ -214,10 +218,7 @@ paths:
                              const: device-added
                              description: Device added to the scene
                            data:
-                             type: object
-                             properties:
-                               device:
-                                 $ref: "#/components/schemas/Device"
+                             $ref: "#/components/schemas/Device"
                       - type: object
                         properties:
                            event:
@@ -226,18 +227,17 @@ paths:
                            data:
                              type: object
                              properties:
-                               device:
-                                 $ref: "#/components/schemas/Device"
+                              category:
+                                  $ref: "#/components/schemas/Category"
+                              mac_address:
+                                  $ref: "#/components/schemas/MacAddress"
                       - type: object
                         properties:
                            event:
                              const: device-updated
                              description: Device position updated
                            data:
-                             type: object
-                             properties:
-                               device:
-                                 $ref: "#/components/schemas/Device"
+                             $ref: "#/components/schemas/Device"
                       - type: object
                         properties:
                            event:
@@ -246,10 +246,14 @@ paths:
                            data:
                              type: object
                              properties:
-                               source-device:
-                                 $ref: "#/components/schemas/Device"
-                               destination-device:
-                                 $ref: "#/components/schemas/Device"
+                               source_category:
+                                 $ref: "#/components/schemas/Category"
+                               source_mac_address:
+                                 $ref: "#/components/schemas/MacAddress"
+                               destination_category:
+                                 $ref: "#/components/schemas/Category"
+                               destination_mac_address:
+                                 $ref: "#/components/schemas/MacAddress"
                                distance:
                                  description: Distance in cm.
                                  type: integer # u16
@@ -258,7 +262,7 @@ paths:
                                azimuth:
                                  description: Azimuth in degrees
                                  type: integer
-                                 minium: -180
+                                 minimum: -180
                                  maximum: 180
                                elevation:
                                  description: Elevation is degrees

--- a/static/src/components/Map.js
+++ b/static/src/components/Map.js
@@ -66,7 +66,7 @@ export class Map extends LitElement {
     if (event.target.classList?.contains("handle")) {
       this.changingElevation = true;
     } else {
-      const element = event.path.find((el) => el.classList?.contains("marker"));
+      const element = event.composedPath().find((el) => el.classList?.contains("marker"));
       if (element) {
         const key = element.getAttribute("key");
         this.selected = this.devices[key];


### PR DESCRIPTION
- Issue #13 Make a clear separation between the library part of pica and the server runner, which is now composed of the previous main.rs and web.rs.

- Issue #9 Update the HTTP API by flattening event objects to make it simpler to remove the dependency on web.