### PR TITLE
Update crate dependencies to integrate with Android emulator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,16 +24,16 @@ default = ["web"]
 web = ["hyper"]
 
 [dependencies]
-tokio = { version = "1.18.5", features = ["full"] }
+tokio = { version = "1.25.0", features = [ "fs", "io-util", "macros", "net", "rt" ] }
 tokio-stream = { version = "0.1.8", features = ["sync"] }
 bytes = "1"
 anyhow = "1.0.56"
 num-derive = "*"
 num-traits = "*"
 thiserror = "*"
-glam = "0.20.3"
+glam = "0.23.0"
 hyper = { version = "0.14", features = ["server", "stream", "http1", "tcp"], optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 hex = "0.4.3"
-clap = { version = "4.1.8", features = ["derive"] }
+clap = { version = "4.1.8", default-features = false, features = ["derive", "error-context", "help", "std", "usage"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/bin/server/mod.rs"
 
 [features]
 default = ["web"]
-web = ["hyper"]
+web = ["hyper", "tokio/rt-multi-thread"]
 
 [dependencies]
 tokio = { version = "1.25.0", features = [ "fs", "io-util", "macros", "net", "rt" ] }


### PR DESCRIPTION
- Android emulator is built by CMake in AOSP emu-master-dev repo.
- Update Cargo.toml to use Rust crates that are available in AOSP.