### PR TITLE
Find peer devices when start ranging.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ impl Connection {
             self.socket
                 .read_exact(&mut complete_packet[0..HEADER_SIZE])
                 .await?;
+            println!("read complete_packet: {:?}", complete_packet);
             let header = PacketHeader::parse(&complete_packet[0..HEADER_SIZE])?;
 
             // Read the packet payload.
@@ -355,7 +356,7 @@ impl Pica {
         self.devices.values().find(|device| {
             if let Some(session) = device.get_session(session_id) {
                 session.app_config.get_device_mac_address() == mac_address
-                    && local_app_config.can_start_ranging_with_peer(session.app_config.clone())
+                    && local_app_config.can_start_ranging_with_peer(&session.app_config.clone())
                     && session.get_session_state() == SessionState::SessionStateActive
             } else {
                 false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,7 +381,7 @@ impl Pica {
     ) -> Option<&Device> {
         self.devices.values().find(|device| {
             if let Some(session) = device.get_session(session_id) {
-                session.app_config.get_device_mac_address() == *mac_address
+                session.app_config.device_mac_address == *mac_address
                     && local_app_config.can_start_ranging_with_peer(&session.app_config)
                     && session.session_state() == SessionState::SessionStateActive
             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,13 +379,13 @@ impl Pica {
     fn get_device_by_mac(
         &self,
         mac_address: MacAddress,
-        local_app_config: AppConfig,
+        local_app_config: &AppConfig,
         session_id: u32,
     ) -> Option<&Device> {
         self.devices.values().find(|device| {
             if let Some(session) = device.get_session(session_id) {
                 session.app_config.get_device_mac_address() == mac_address
-                    && local_app_config.can_start_ranging_with_peer(&session.app_config.clone())
+                    && local_app_config.can_start_ranging_with_peer(&session.app_config)
                     && session.get_session_state() == SessionState::SessionStateActive
             } else {
                 false
@@ -506,7 +506,7 @@ impl Pica {
                     add_measurement(mac_address, &mut measurements, local, remote);
                 }
                 if let Some(peer_device) =
-                    self.get_device_by_mac(*mac_address, session.app_config.clone(), session_id)
+                    self.get_device_by_mac(*mac_address, &session.app_config, session_id)
                 {
                     let local: (u16, i16, i8) = device
                         .position

--- a/src/session.rs
+++ b/src/session.rs
@@ -338,6 +338,50 @@ impl Default for AppConfig {
     }
 }
 
+impl PartialEq for AppConfig {
+    fn eq(&self, other: &Self) -> bool {
+        self.mac_address_mode == other.mac_address_mode
+            && self.ranging_interval == other.ranging_interval
+            && self.slot_duration == other.slot_duration
+            && self.channel_number == other.channel_number
+            && self.multi_node_mode == other.multi_node_mode
+            && self.ranging_round_usage == other.ranging_round_usage
+            && self.sts_config == other.sts_config
+            && self.mac_fcs_type == other.mac_fcs_type
+            && self.ranging_round_control == other.ranging_round_control
+            && self.aoa_result_req == other.aoa_result_req
+            && self.rng_data_ntf == other.rng_data_ntf
+            && self.rng_data_ntf_proximity_near == other.rng_data_ntf_proximity_near
+            && self.rng_data_ntf_proximity_far == other.rng_data_ntf_proximity_far
+            && self.r_frame_config == other.r_frame_config
+            && self.rssi_reporting == other.rssi_reporting
+            && self.preamble_code_index == other.preamble_code_index
+            && self.sfd_id == other.sfd_id
+            && self.psdu_data_rate == other.psdu_data_rate
+            && self.preamble_duration == other.preamble_duration
+            && self.ranging_time_struct == other.ranging_time_struct
+            && self.slots_per_rr == other.slots_per_rr
+            && self.tx_adaptive_payload_power == other.tx_adaptive_payload_power
+            && self.prf_mode == other.prf_mode
+            && self.schedule_mode == other.schedule_mode
+            && self.key_rotation == other.key_rotation
+            && self.key_rotation_rate == other.key_rotation_rate
+            && self.session_priority == other.session_priority
+            && self.number_of_sts_segments == other.number_of_sts_segments
+            && self.max_rr_retry == other.max_rr_retry
+            && self.hopping_mode == other.hopping_mode
+            && self.block_stride_length == other.block_stride_length
+            && self.result_report_config == other.result_report_config
+            && self.in_band_termination_attempt_count == other.in_band_termination_attempt_count
+            && self.bprf_phr_data_rate == other.bprf_phr_data_rate
+            && self.max_number_of_measurements == other.max_number_of_measurements
+            && self.sts_length == other.sts_length
+            && self.uwb_initiation_time == other.uwb_initiation_time
+            && self.vendor_id == other.vendor_id
+            && self.static_sts_iv == other.static_sts_iv
+    }
+}
+
 fn app_config_has_mandatory_parameters(configs: &[AppConfigTlv]) -> bool {
     const MANDATORY_PARAMETERS: [AppConfigTlvType; 6] = [
         AppConfigTlvType::DeviceRole,
@@ -533,55 +577,16 @@ impl AppConfig {
         self.raw.get(&id).cloned()
     }
 
-    pub fn can_start_ranging_with_peer(&self, peer_config: Self) -> bool {
-        self.device_role != peer_config.device_role
+    pub fn can_start_ranging_with_peer(&self, peer_config: &Self) -> bool {
+        self == peer_config
+            && self.device_role != peer_config.device_role
             && self.device_type != peer_config.device_type
-            && self.mac_address_mode == peer_config.mac_address_mode
-            && self.ranging_interval == peer_config.ranging_interval
-            && self.slot_duration == peer_config.slot_duration
-            && self.channel_number == peer_config.channel_number
             && peer_config
                 .dst_mac_addresses
                 .contains(&self.device_mac_address)
             && self
                 .dst_mac_addresses
                 .contains(&peer_config.device_mac_address)
-            && self.multi_node_mode == peer_config.multi_node_mode
-            && self.ranging_round_usage == peer_config.ranging_round_usage
-            && self.sts_config == peer_config.sts_config
-            && self.mac_fcs_type == peer_config.mac_fcs_type
-            && self.ranging_round_control == peer_config.ranging_round_control
-            && self.aoa_result_req == peer_config.aoa_result_req
-            && self.rng_data_ntf == peer_config.rng_data_ntf
-            && self.rng_data_ntf_proximity_near == peer_config.rng_data_ntf_proximity_near
-            && self.rng_data_ntf_proximity_far == peer_config.rng_data_ntf_proximity_far
-            && self.r_frame_config == peer_config.r_frame_config
-            && self.rssi_reporting == peer_config.rssi_reporting
-            && self.preamble_code_index == peer_config.preamble_code_index
-            && self.sfd_id == peer_config.sfd_id
-            && self.psdu_data_rate == peer_config.psdu_data_rate
-            && self.preamble_duration == peer_config.preamble_duration
-            && self.ranging_time_struct == peer_config.ranging_time_struct
-            && self.slots_per_rr == peer_config.slots_per_rr
-            && self.tx_adaptive_payload_power == peer_config.tx_adaptive_payload_power
-            && self.prf_mode == peer_config.prf_mode
-            && self.schedule_mode == peer_config.schedule_mode
-            && self.key_rotation == peer_config.key_rotation
-            && self.key_rotation_rate == peer_config.key_rotation_rate
-            && self.session_priority == peer_config.session_priority
-            && self.number_of_sts_segments == peer_config.number_of_sts_segments
-            && self.max_rr_retry == peer_config.max_rr_retry
-            && self.hopping_mode == peer_config.hopping_mode
-            && self.block_stride_length == peer_config.block_stride_length
-            && self.result_report_config == peer_config.result_report_config
-            && self.in_band_termination_attempt_count
-                == peer_config.in_band_termination_attempt_count
-            && self.bprf_phr_data_rate == peer_config.bprf_phr_data_rate
-            && self.max_number_of_measurements == peer_config.max_number_of_measurements
-            && self.sts_length == peer_config.sts_length
-            && self.uwb_initiation_time == peer_config.uwb_initiation_time
-            && self.vendor_id == peer_config.vendor_id
-            && self.static_sts_iv == peer_config.static_sts_iv
     }
 
     pub fn get_device_mac_address(&self) -> MacAddress {

--- a/src/session.rs
+++ b/src/session.rs
@@ -243,7 +243,7 @@ pub struct AppConfig {
     device_type: DeviceType,
     device_role: DeviceRole,
     mac_address_mode: MacAddressMode,
-    device_mac_address: MacAddress,
+    pub device_mac_address: MacAddress,
     number_of_controlees: usize,
     dst_mac_addresses: Vec<MacAddress>,
     ranging_interval: time::Duration,
@@ -587,10 +587,6 @@ impl AppConfig {
             && self
                 .dst_mac_addresses
                 .contains(&peer_config.device_mac_address)
-    }
-
-    pub fn get_device_mac_address(&self) -> MacAddress {
-        self.device_mac_address
     }
 
     fn extend(&mut self, configs: &[AppConfigTlv]) -> Vec<AppConfigStatus> {

--- a/src/session.rs
+++ b/src/session.rs
@@ -682,7 +682,7 @@ impl Session {
         self.app_config.rng_data_ntf
     }
 
-    pub fn get_session_state(&self) -> SessionState {
+    pub fn session_state(&self) -> SessionState {
         self.state
     }
 


### PR DESCRIPTION
Compare the AppConfig to determine whether two devices can start ranging with each other. They can ranging if they:
* have opposite `DeviceType` and `DeviceRole`
* `mac_address` is contained in the other device's `dst_mac_address`
* same other app configs
