### PR TITLE
Refactor packet framing to support generic streams

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,8 +243,9 @@ fn make_measurement(
 }
 
 impl Pica {
-    pub fn new(event_tx: broadcast::Sender<PicaEvent>, pcapng_dir: Option<PathBuf>) -> Self {
+    pub fn new(pcapng_dir: Option<PathBuf>) -> Self {
         let (tx, rx) = mpsc::channel(MAX_SESSION * MAX_DEVICE);
+        let (event_tx, _) = broadcast::channel(16);
         Pica {
             devices: HashMap::new(),
             anchors: HashMap::new(),
@@ -254,6 +255,10 @@ impl Pica {
             event_tx,
             pcapng_dir,
         }
+    }
+
+    pub fn events(&self) -> broadcast::Sender<PicaEvent> {
+        self.event_tx.clone()
     }
 
     pub fn tx(&self) -> mpsc::Sender<PicaCommand> {

--- a/src/packets.rs
+++ b/src/packets.rs
@@ -24,4 +24,167 @@ pub mod uci {
     #![allow(missing_docs)]
 
     include!(concat!(env!("OUT_DIR"), "/uci_packets.rs"));
+
+    /// Size of common UCI packet header.
+    pub const COMMON_HEADER_SIZE: usize = 1;
+    /// Size of UCI packet headers.
+    pub const HEADER_SIZE: usize = 4;
+    /// Maximum size of an UCI control packet payload.
+    pub const MAX_CTRL_PACKET_PAYLOAD_SIZE: usize = 255;
+    /// Maximum size of an UCI data packet payload.
+    pub const MAX_DATA_PACKET_PAYLOAD_SIZE: usize = 1024;
+
+    // Extract the message type from the first 3 bits of the passed (header) byte
+    pub fn parse_message_type(byte: u8) -> MessageType {
+        MessageType::try_from((byte >> 5) & 0x7).unwrap_or(MessageType::Command)
+    }
+
+    use crate::pcapng;
+    use std::pin::Pin;
+    use tokio::io::{AsyncRead, AsyncWrite};
+    use tokio::sync::Mutex;
+
+    /// Read UCI Control and Data packets received on the UCI transport.
+    /// Performs recombination of the segmented packets.
+    pub struct Reader {
+        socket: Pin<Box<dyn AsyncRead + Send>>,
+    }
+
+    /// Write UCI Control and Data packets received to the UCI transport.
+    /// Performs segmentation of the packets.
+    pub struct Writer {
+        socket: Pin<Box<dyn AsyncWrite + Send>>,
+    }
+
+    impl Reader {
+        /// Create an UCI reader from an UCI transport.
+        pub fn new<T: AsyncRead + Send + 'static>(rx: T) -> Self {
+            Reader {
+                socket: Box::pin(rx),
+            }
+        }
+
+        /// Read a single UCI packet from the reader. The packet is automatically
+        /// re-assembled if segmented on the UCI transport. Data segments
+        /// are _not_ re-assembled but returned immediatly for credit
+        /// acknowledgment.
+        pub async fn read(&mut self, pcapng: &mut Option<pcapng::File>) -> anyhow::Result<Vec<u8>> {
+            use tokio::io::AsyncReadExt;
+
+            let mut complete_packet = vec![0; HEADER_SIZE];
+
+            // Note on reassembly:
+            // For each segment of a Control Message, the
+            // header of the Control Packet SHALL contain the same MT, GID and OID
+            // values. It is correct to keep only the last header of the segmented packet.
+            loop {
+                // Read the common packet header.
+                self.socket
+                    .read_exact(&mut complete_packet[0..HEADER_SIZE])
+                    .await?;
+                let common_packet_header =
+                    PacketHeader::parse(&complete_packet[0..COMMON_HEADER_SIZE])?;
+
+                // Read the packet payload.
+                let payload_length = match common_packet_header.get_mt() {
+                    MessageType::Data => {
+                        let data_packet_header =
+                            DataPacketHeader::parse(&complete_packet[0..HEADER_SIZE])?;
+                        data_packet_header.get_payload_length() as usize
+                    }
+                    _ => {
+                        let control_packet_header =
+                            ControlPacketHeader::parse(&complete_packet[0..HEADER_SIZE])?;
+                        control_packet_header.get_payload_length() as usize
+                    }
+                };
+                let mut payload_bytes = vec![0; payload_length];
+                self.socket.read_exact(&mut payload_bytes).await?;
+                complete_packet.extend(&payload_bytes);
+
+                if let Some(ref mut pcapng) = pcapng {
+                    let mut packet_bytes = vec![];
+                    packet_bytes.extend(&complete_packet[0..HEADER_SIZE]);
+                    packet_bytes.extend(&payload_bytes);
+                    pcapng.write(&packet_bytes, pcapng::Direction::Tx).await?;
+                }
+
+                if common_packet_header.get_mt() == MessageType::Data {
+                    return Ok(complete_packet);
+                }
+
+                // Check the Packet Boundary Flag.
+                match common_packet_header.get_pbf() {
+                    PacketBoundaryFlag::Complete => return Ok(complete_packet),
+                    PacketBoundaryFlag::NotComplete => (),
+                }
+            }
+        }
+    }
+
+    impl Writer {
+        /// Create an UCI writer from an UCI transport.
+        pub fn new<T: AsyncWrite + Send + 'static>(rx: T) -> Self {
+            Writer {
+                socket: Box::pin(rx),
+            }
+        }
+
+        /// Write a single UCI packet to the writer. The packet is automatically
+        /// segmented if the payload exceeds the maximum size limit.
+        pub async fn write(
+            &mut self,
+            mut packet: &[u8],
+            pcapng: &mut Option<pcapng::File>,
+        ) -> anyhow::Result<()> {
+            use tokio::io::AsyncWriteExt;
+
+            let mut header_bytes = [packet[0], packet[1], packet[2], 0];
+            packet = &packet[HEADER_SIZE..];
+
+            loop {
+                let message_type = parse_message_type(header_bytes[0]);
+                let chunk_length = std::cmp::min(
+                    packet.len(),
+                    match message_type {
+                        MessageType::Data => MAX_DATA_PACKET_PAYLOAD_SIZE,
+                        _ => MAX_CTRL_PACKET_PAYLOAD_SIZE,
+                    },
+                );
+                // Update header with framing information.
+                let pbf = if chunk_length < packet.len() {
+                    PacketBoundaryFlag::NotComplete
+                } else {
+                    PacketBoundaryFlag::Complete
+                };
+                const PBF_MASK: u8 = 0x10;
+                header_bytes[0] &= !PBF_MASK;
+                header_bytes[0] |= (pbf as u8) << 4;
+
+                match message_type {
+                    MessageType::Data => {
+                        let chunk_le_bytes = (chunk_length as u16).to_le_bytes();
+                        header_bytes[2..4].copy_from_slice(&chunk_le_bytes);
+                    }
+                    _ => header_bytes[3] = chunk_length as u8,
+                }
+
+                if let Some(ref mut pcapng) = pcapng {
+                    let mut packet_bytes = vec![];
+                    packet_bytes.extend(&header_bytes);
+                    packet_bytes.extend(&packet[..chunk_length]);
+                    pcapng.write(&packet_bytes, pcapng::Direction::Rx).await?
+                }
+
+                // Write the header and payload segment bytes.
+                self.socket.write_all(&header_bytes).await?;
+                self.socket.write_all(&packet[..chunk_length]).await?;
+                packet = &packet[chunk_length..];
+
+                if packet.is_empty() {
+                    return Ok(());
+                }
+            }
+        }
+    }
 }

--- a/src/pcapng.rs
+++ b/src/pcapng.rs
@@ -60,28 +60,20 @@ impl File {
         let packet_data_padding: usize = 4 - packet.len() % 4;
         let block_total_length: u32 = packet.len() as u32 + packet_data_padding as u32 + 32;
         let timestamp = self.start_time.elapsed().as_micros();
+        let file = &mut self.file;
 
         // Wrap the packet inside an Enhanced Packet Block.
-        self.file.write(&u32::to_le_bytes(0x00000006)).await?; // Block Type
-        self.file
-            .write(&u32::to_le_bytes(block_total_length))
-            .await?;
-        self.file.write(&u32::to_le_bytes(0)).await?; // Interface ID
-        self.file
-            .write(&u32::to_le_bytes((timestamp >> 32) as u32))
+        file.write(&u32::to_le_bytes(0x00000006)).await?; // Block Type
+        file.write(&u32::to_le_bytes(block_total_length)).await?;
+        file.write(&u32::to_le_bytes(0)).await?; // Interface ID
+        file.write(&u32::to_le_bytes((timestamp >> 32) as u32))
             .await?; // Timestamp (High)
-        self.file.write(&u32::to_le_bytes(timestamp as u32)).await?; // Timestamp (Low)
-        self.file
-            .write(&u32::to_le_bytes(packet.len() as u32))
-            .await?; // Captured Packet Length
-        self.file
-            .write(&u32::to_le_bytes(packet.len() as u32))
-            .await?; // Original Packet Length
-        self.file.write(packet).await?;
-        self.file.write(&vec![0; packet_data_padding]).await?;
-        self.file
-            .write(&u32::to_le_bytes(block_total_length))
-            .await?; // Block Total Length
+        file.write(&u32::to_le_bytes(timestamp as u32)).await?; // Timestamp (Low)
+        file.write(&u32::to_le_bytes(packet.len() as u32)).await?; // Captured Packet Length
+        file.write(&u32::to_le_bytes(packet.len() as u32)).await?; // Original Packet Length
+        file.write(packet).await?;
+        file.write(&vec![0; packet_data_padding]).await?;
+        file.write(&u32::to_le_bytes(block_total_length)).await?; // Block Total Length
         Ok(())
     }
 }


### PR DESCRIPTION
- introduce packets::nci::Reader and packets::nci::Writer
  which wrap around dyn AsyncRead and dyn AsyncWrite respectively
- the methods Reader::read and Writer::write perform the logic
  previoulsy implemented in Conntection::read and Connection::write
