### PR TITLE
Explicitely set the mac address for UCI devices

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -88,16 +88,13 @@ pub struct Device {
 
 impl Device {
     pub fn new(
-        device_handle: usize,
+        handle: usize,
+        mac_address: MacAddress,
         tx: mpsc::Sender<UciPacket>,
         pica_tx: mpsc::Sender<PicaCommand>,
     ) -> Self {
-        let mac_address = {
-            let handle = device_handle as u16;
-            MacAddress::Short(handle.to_be_bytes())
-        };
         Device {
-            handle: device_handle,
+            handle,
             mac_address,
             state: DeviceState::DeviceStateError, // Will be overwitten
             sessions: Default::default(),
@@ -182,7 +179,12 @@ impl Device {
         let status = match reset_config {
             ResetConfig::UwbsReset => StatusCode::UciStatusOk,
         };
-        *self = Device::new(self.handle, self.tx.clone(), self.pica_tx.clone());
+        *self = Device::new(
+            self.handle,
+            self.mac_address,
+            self.tx.clone(),
+            self.pica_tx.clone(),
+        );
         self.init();
 
         DeviceResetRspBuilder { status }.build()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,7 +320,13 @@ impl Pica {
         log::debug!("[{}] Connecting device", device_handle);
 
         self.counter += 1;
-        let mut device = Device::new(device_handle, packet_tx, self.command_tx.clone());
+        let mac_address = MacAddress::Short((device_handle as u16).to_be_bytes());
+        let mut device = Device::new(
+            device_handle,
+            mac_address,
+            packet_tx,
+            self.command_tx.clone(),
+        );
         device.init();
 
         self.send_event(PicaEvent::Connected {


### PR DESCRIPTION
- previously derived from the device handle
- configuring the mac address from new() parameters
  ensures we can make it configurable in the future
