### PR TITLE
Implement pica::run(Mutex<Pica>)

### DIFF
--- a/src/bin/http-server/main.rs
+++ b/src/bin/http-server/main.rs
@@ -542,7 +542,7 @@ async fn main() -> Result<()> {
 
     let context = Context::new();
 
-    let mut pica = Pica::new(Box::new(context.clone()), args.pcapng_dir);
+    let pica = Pica::new(Box::new(context.clone()), args.pcapng_dir);
     let cmd_tx = pica.commands();
     let events_rx = pica.events();
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<()> {
 
     let args = Args::parse();
 
-    let mut pica = Pica::new(Box::new(MockRangingEstimator()), args.pcapng_dir);
+    let pica = Pica::new(Box::new(MockRangingEstimator()), args.pcapng_dir);
     let commands = pica.commands();
 
     try_join!(accept_incoming(commands.clone(), args.uci_port), pica.run(),)?;

--- a/src/device.rs
+++ b/src/device.rs
@@ -78,7 +78,7 @@ pub struct Device {
     /// [UCI] 5. UWBS Device State Machine
     state: DeviceState,
     sessions: HashMap<u32, Session>,
-    pub tx: mpsc::Sender<UciPacket>,
+    pub tx: mpsc::UnboundedSender<UciPacket>,
     pica_tx: mpsc::Sender<PicaCommand>,
     config: HashMap<DeviceConfigId, Vec<u8>>,
     country_code: [u8; 2],
@@ -90,7 +90,7 @@ impl Device {
     pub fn new(
         handle: usize,
         mac_address: MacAddress,
-        tx: mpsc::Sender<UciPacket>,
+        tx: mpsc::UnboundedSender<UciPacket>,
         pica_tx: mpsc::Sender<PicaCommand>,
     ) -> Self {
         Device {
@@ -118,7 +118,6 @@ impl Device {
         tokio::spawn(async move {
             time::sleep(Duration::from_millis(5)).await;
             tx.send(DeviceStatusNtfBuilder { device_state }.build().into())
-                .await
                 .unwrap()
         });
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -734,7 +734,7 @@ pub struct Session {
     pub sequence_number: u32,
     pub app_config: AppConfig,
     ranging_task: Option<JoinHandle<()>>,
-    tx: mpsc::Sender<UciPacket>,
+    tx: mpsc::UnboundedSender<UciPacket>,
     pica_tx: mpsc::Sender<PicaCommand>,
 }
 
@@ -743,7 +743,7 @@ impl Session {
         id: u32,
         session_type: SessionType,
         device_handle: usize,
-        tx: mpsc::Sender<UciPacket>,
+        tx: mpsc::UnboundedSender<UciPacket>,
         pica_tx: mpsc::Sender<PicaCommand>,
     ) -> Self {
         Self {
@@ -781,7 +781,6 @@ impl Session {
                 .build()
                 .into(),
             )
-            .await
             .unwrap()
         });
     }
@@ -1103,7 +1102,6 @@ impl Session {
                 .build()
                 .into(),
             )
-            .await
             .unwrap()
         });
         SessionUpdateControllerMulticastListRspBuilder { status }.build()


### PR DESCRIPTION
- enables synchronous access to the context.
  Typically a client application could
  create the Pica context as lazy_static,
  spawn a task for loop { pica::run(ctx); }
  and still access the context synchronously
  for connection management

- requires making all the pica command handlers synchronous
  to ensure that the mutex does not need to be held accross
  wait boundaries
