### PR TITLE
Update the format of the notification Update Controller Multicast List

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -690,7 +690,6 @@ impl Device {
                             MacAddress::Short(address) => address,
                             MacAddress::Extended(_) => panic!("Extended address is not supported!"),
                         },
-                        subsession_id: controlee.sub_session_id,
                         status: update_status,
                     });
                 });
@@ -726,7 +725,6 @@ impl Device {
                             MacAddress::Short(addr) => addr,
                             MacAddress::Extended(_) => panic!("Extended address is not supported!"),
                         },
-                        subsession_id: controlee.sub_session_id,
                         status: update_status,
                     });
                 });
@@ -745,10 +743,13 @@ impl Device {
         }
         let tx = self.tx.clone();
         tokio::spawn(async move {
+            // Sleep for 5ms to make sure the notification is not being
+            // sent before the response.
+            // TODO(#84) remove the sleep.
+            time::sleep(Duration::from_millis(5)).await;
             tx.send(
                 SessionUpdateControllerMulticastListNtfBuilder {
                     controlee_status,
-                    remaining_multicast_list_size: dst_addresses.len() as u8,
                     session_token: session_handle,
                 }
                 .build()
@@ -1069,6 +1070,7 @@ impl Device {
 
 struct Controlee {
     short_address: MacAddress,
+    #[allow(dead_code)]
     sub_session_id: u32,
     #[allow(dead_code)]
     session_key: SubSessionKey,

--- a/src/uci_packets.pdl
+++ b/src/uci_packets.pdl
@@ -1078,13 +1078,11 @@ test SessionUpdateControllerMulticastListRsp {
 
 struct ControleeStatus {
     mac_address: 8[2],
-    subsession_id: 32,
     status: MulticastUpdateStatus,
 }
 
 packet SessionUpdateControllerMulticastListNtf : SessionConfigPacket (mt = NOTIFICATION, oid = UPDATE_CONTROLLER_MULTICAST_LIST) {
     session_token: 32, // Session ID or Session Handle (based on UWBS version)
-    remaining_multicast_list_size: 8,
     _count_(controlee_status): 8,
     controlee_status: ControleeStatus[],
 }


### PR DESCRIPTION
The previous version implemented UCI 1.0, now that pica implements UCI 2.0
the format needs to be updated.
