### PR TITLE
Only send multicastNtf back in delete action.

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -741,9 +741,9 @@ impl Device {
                 });
                 // Following requirements are applicable when the action is set to Delete (Action field set to 0x01):
                 // When the command is received while the Session State is SESSION_STATE_ACTIVE,
-                // For requested Controlees present in the multicast list, 
+                // For requested Controlees present in the multicast list,
                 // UWBS shall send the SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF and the
-                // corresponding Controlee status shall be set to STATUS_OK_MULTICAST_LIST_UPDATE 
+                // corresponding Controlee status shall be set to STATUS_OK_MULTICAST_LIST_UPDATE
                 // in the Status List of SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF.
                 if session.state == SessionState::SessionStateActive {
                     let tx = self.tx.clone();

--- a/src/device.rs
+++ b/src/device.rs
@@ -739,23 +739,31 @@ impl Device {
                         status: update_status,
                     });
                 });
-                let tx = self.tx.clone();
-                tokio::spawn(async move {
-                    // Sleep for 5ms to make sure the notification is not being
-                    // sent before the response.
-                    // TODO(#84) remove the sleep.
-                    time::sleep(Duration::from_millis(5)).await;
-                    tx.send(
-                        SessionUpdateControllerMulticastListNtfBuilder {
-                            controlee_status,
-                            session_token: session_handle,
-                        }
-                        .build()
-                        .encode_to_vec()
-                        .unwrap(),
-                    )
-                    .unwrap()
-                });
+                // Following requirements are applicable when the action is set to Delete (Action field set to 0x01):
+                // When the command is received while the Session State is SESSION_STATE_ACTIVE,
+                // For requested Controlees present in the multicast list, 
+                // UWBS shall send the SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF and the
+                // corresponding Controlee status shall be set to STATUS_OK_MULTICAST_LIST_UPDATE 
+                // in the Status List of SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF.
+                if session.state == SessionState::SessionStateActive {
+                    let tx = self.tx.clone();
+                    tokio::spawn(async move {
+                        // Sleep for 5ms to make sure the notification is not being
+                        // sent before the response.
+                        // TODO(#84) remove the sleep.
+                        time::sleep(Duration::from_millis(5)).await;
+                        tx.send(
+                            SessionUpdateControllerMulticastListNtfBuilder {
+                                controlee_status,
+                                session_token: session_handle,
+                            }
+                            .build()
+                            .encode_to_vec()
+                            .unwrap(),
+                        )
+                        .unwrap()
+                    });
+                }
             }
         }
         session.app_config.number_of_controlees = dst_addresses.len() as u8;


### PR DESCRIPTION
From Fira 2.0 spec:
The UWBS shall send the SESSION_UPDATE_CONTROLLER_MULTICAST_LIST_NTF only in case of an error encountered when the session is started, after receiving the RANGE_START_CMD from the Host. This scenario can be encountered only when the UWBS fails to fetch the Session key/Sub-Session Key from the Secure Component.

Since we get session key/sub-session key from host, we don't need to send ntf
back. So move the logic into RemoveControlee branch.
