### PR TITLE
Detect bad host states

### DIFF
--- a/src/packets.rs
+++ b/src/packets.rs
@@ -25,6 +25,18 @@ pub mod uci {
 
     include!(concat!(env!("OUT_DIR"), "/uci_packets.rs"));
 
+    impl ControlPacket {
+        pub fn is_core_device_reset_cmd(&self) -> bool {
+            matches!(
+                self.controlpacket.child,
+                ControlPacketDataChild::CorePacket(CorePacketData {
+                    child: CorePacketDataChild::CoreDeviceResetCmd(_),
+                    ..
+                })
+            )
+        }
+    }
+
     /// Size of common UCI packet header.
     pub const COMMON_HEADER_SIZE: usize = 1;
     /// Size of UCI packet headers.


### PR DESCRIPTION
Generate a Core Device Status Ntf with state error when
commands are received before the Core Device Reset command