### PR TITLE
Return status 33 when ranging is not available between devices.

### DIFF
--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -499,12 +499,16 @@ impl AppConfig {
     pub fn is_compatible_for_ranging(&self, peer_config: &Self) -> bool {
         self.device_role != peer_config.device_role
             && self.device_type != peer_config.device_type
-            && peer_config
-                .dst_mac_address
-                .contains(&self.device_mac_address.unwrap())
             && self
                 .dst_mac_address
                 .contains(&peer_config.device_mac_address.unwrap())
+    }
+
+    pub fn can_start_ranging(&self, peer_config: &Self) -> bool {
+        self.is_compatible_for_ranging(&peer_config)
+            && peer_config
+                .dst_mac_address
+                .contains(&self.device_mac_address.unwrap())
     }
 
     pub fn can_start_data_transfer(&self) -> bool {

--- a/src/device.rs
+++ b/src/device.rs
@@ -165,13 +165,23 @@ impl Device {
         self.sessions.get_mut(&session_id)
     }
 
+    pub fn is_compatible_for_ranging(&self, peer_session: &Session, session_id: u32) -> bool {
+        if let Some(session) = self.session(session_id) {
+            session
+                .app_config
+                .is_compatible_for_ranging(&peer_session.app_config)
+        } else {
+            false
+        }
+    }
+
     pub fn can_start_ranging(&self, peer_session: &Session, session_id: u32) -> bool {
         match self.session(session_id) {
             Some(session) => {
                 session.session_state() == SessionState::SessionStateActive
                     && session
                         .app_config
-                        .is_compatible_for_ranging(&peer_session.app_config)
+                        .can_start_ranging(&peer_session.app_config)
             }
             None => false,
         }


### PR DESCRIPTION
We should not send ShortMacTwoWaySessionInfoNtf with no measurement back
to host. Instead, send measurement with status 33 when ranging is not
available.