### PR TITLE
Fix devices disappearing when web interface is refreshed

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -76,6 +76,30 @@ limitations under the License.
   const map = document.getElementById("map");
   const info = document.getElementById("info");
 
+  function parse_device(device) {
+    const {
+      mac_address, x, y, z, yaw, pitch, roll,
+    } = device;
+    return {
+      mac_address,
+      position: { x, y, z },
+      yaw,
+      pitch,
+      roll,
+      neighbors: []
+    }
+  }
+
+  async function update_state() {
+    const res = await fetch('/get-state');
+    const { devices } = await res.json();
+    map.devices = devices.map(device => parse_device(device));
+  }
+
+  window.addEventListener('load', async () => {
+    update_state();
+  });
+
   map.addEventListener(
     "select",
     (event) => (info.device = event.detail.device)
@@ -122,19 +146,9 @@ limitations under the License.
     const data = JSON.parse(event.data);
     console.log("Device Added", data);
 
-    const {
-      mac_address, x, y, z, yaw, pitch, roll,
-    } = data;
     map.devices = [
       ...map.devices,
-      {
-        mac_address,
-        position: { x, y, z },
-        yaw,
-        pitch,
-        roll,
-        neighbors: [],
-      },
+      parse_device(data)
     ];
   });
 


### PR DESCRIPTION
When the page is loaded, call '/get-state' API to fetch all the existing devices and render them in the map.

This fixes the bug where refreshing the page would clear all the devices from the UI.

fixes #100


https://github.com/user-attachments/assets/7b3ec45f-81c2-4092-9ea6-01865909b600

